### PR TITLE
Parse and compact ingredient quantity representations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 flask = "==1.1.1"
 ingreedypy = "==1.1"
 gunicorn = "==19.9.0"
+pint = "==0.9"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pint = "==0.9"
 [dev-packages]
 flake8 = "*"
 pytest = "==4.6.5"
+mock = "*"
 
 [requires]
 python_version = "2.7"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,6 +1,8 @@
+from mock import patch
 import pytest
 
 from web.app import parse_description_ingreedypy
+
 
 def parser_tests():
     return {
@@ -16,10 +18,28 @@ def parser_tests():
         },
     }
 
+
 @pytest.mark.parametrize('description, expected', parser_tests().items())
-def test_request(description, expected):
+def test_parse_description_ingreedypy(description, expected):
     expected.update({'input': description, 'parser': 'ingreedypy'})
 
     result = parse_description_ingreedypy(description)
 
     assert result == expected
+
+
+def nyt_parser_stub(descriptions):
+    return [{'input': description} for description in descriptions]
+
+
+@patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
+def test_request(client):
+    response = client.post('/', data={'descriptions[]': ['tomato']})
+
+    assert response.json == [{
+        'description': 'tomato',
+        'product': {
+            'product': 'tomato',
+            'product_parser': 'ingreedypy'
+        }
+    }]

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -34,12 +34,16 @@ def nyt_parser_stub(descriptions):
 
 @patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
 def test_request(client):
-    response = client.post('/', data={'descriptions[]': ['tomato']})
+    response = client.post('/', data={'descriptions[]': ['100ml red wine']})
 
     assert response.json == [{
-        'description': 'tomato',
+        'description': '100ml red wine',
         'product': {
-            'product': 'tomato',
-            'product_parser': 'ingreedypy'
-        }
+            'product': 'red wine',
+            'product_parser': 'ingreedypy',
+        },
+        'units': 'milliliter',
+        'units_parser': 'ingreedypy',
+        'quantity': 100,
+        'quantity_parser': 'ingreedypy'
     }]

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -34,6 +34,41 @@ def nyt_parser_stub(descriptions):
 
 @patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
 def test_request(client):
+    response = client.post('/', data={
+        'descriptions[]': [
+            '100ml red wine',
+            '1000 grams potatoes',
+        ]
+    })
+
+    assert response.json == [{
+        'description': '100ml red wine',
+        'product': {
+            'product': 'red wine',
+            'product_parser': 'ingreedypy',
+        },
+        'units': 'ml',
+        'units_parser': 'ingreedypy+pint',
+        'quantity': 100,
+        'quantity_parser': 'ingreedypy+pint'
+    }, {
+        'description': '1000 grams potatoes',
+        'product': {
+            'product': 'potatoes',
+            'product_parser': 'ingreedypy',
+        },
+        'units': 'kg',
+        'units_parser': 'ingreedypy+pint',
+        'quantity': 1,
+        'quantity_parser': 'ingreedypy+pint'
+    }]
+
+
+@patch('web.app.parse_units')
+@patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
+def test_request_unit_parse_failure(parse_units, client):
+    parse_units.side_effect = [Exception]
+
     response = client.post('/', data={'descriptions[]': ['100ml red wine']})
 
     assert response.json == [{

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,2 +1,25 @@
-def test_request(client):
-    client.post('/')
+import pytest
+
+from web.app import parse_description_ingreedypy
+
+def parser_tests():
+    return {
+        'tomato': {
+            'product': 'tomato',
+            'quantity': None,
+            'units': None
+        },
+        '1 kilogram beef': {
+            'product': 'beef',
+            'quantity': 1,
+            'units': 'kilogram'
+        },
+    }
+
+@pytest.mark.parametrize('description, expected', parser_tests().items())
+def test_request(description, expected):
+    expected.update({'input': description, 'parser': 'ingreedypy'})
+
+    result = parse_description_ingreedypy(description)
+
+    assert result == expected


### PR DESCRIPTION
This changeset introduces the `pint` library to the `ingredient-parser` service, to canonicalize and compact the representations of ingredient units & quantities.

The `units_parser` and `quantity_parser` fields on each ingredient are updated if `pint` is able to parse them.  Once all ingredients are recrawled, it'll be possible to run a backend database query to identify remaining units which need to be supported by the parser (i.e. `tablespoon`, etc).

This changeset doesn't specify a 'base' unit for each dimension; that might be a useful standardization in future, but can be reconsidered once quantity rendering is implemented end-to-end.