### PR TITLE
Special case handling for 'pinch'

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,22 @@
+import pytest
+
+from web.app import parse_units
+
+
+def parser_tests():
+    return {
+        '0.25 ml': {
+            'parser': 'example',
+            'product': 'paprika',
+            'quantity': 1,
+            'units': 'pinch'
+        },
+    }
+
+
+@pytest.mark.parametrize('expected, ingredient', parser_tests().items())
+def test_parse_units(expected, ingredient):
+    result = parse_units(ingredient)
+    result = '{} {}'.format(result['quantity'], result['units'])
+
+    assert result == expected

--- a/web/app.py
+++ b/web/app.py
@@ -101,6 +101,7 @@ def parse_units(ingredient):
     if base_units:
         quantity = quantity.to(base_units)
 
+    # TODO: This is ugly; we shouldn't be rounding/casting arbitrarily
     if quantity.magnitude > 1:
         result_quantity = int(quantity.magnitude)
     else:

--- a/web/app.py
+++ b/web/app.py
@@ -83,6 +83,12 @@ def get_base_units(quantity):
 
 
 def parse_units(ingredient):
+    # Workaround: pint treats 'pinch' as 'pico-inch'
+    # https://github.com/hgrecco/pint/issues/273
+    if ingredient and ingredient.get('units') == 'pinch':
+        ingredient['units'] = 'ml'
+        ingredient['quantity'] = ingredient.get('quantity', 1) * 0.25
+
     try:
         quantity = unit_registry.Quantity(
             ingredient.get('quantity'),
@@ -95,8 +101,13 @@ def parse_units(ingredient):
     if base_units:
         quantity = quantity.to(base_units)
 
+    if quantity.magnitude > 1:
+        result_quantity = int(quantity.magnitude)
+    else:
+        result_quantity = round(quantity.magnitude, 2)
+
     result = {
-        'quantity': int(quantity.magnitude),
+        'quantity': result_quantity,
         'quantity_parser': ingredient['parser'] + '+pint'
     }
     result.update({


### PR DESCRIPTION
`pint` has been parsing `pinch` as `pino-inch`, which is very smart but not particularly useful!