### PR TITLE
Improve handling of ingredients containing 'alternative' units

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 flask = "==1.1.1"
-ingreedypy = "==1.1"
+ingreedypy = { git = "https://github.com/openculinary/ingreedy-py.git", ref = "4a5f165" }
 gunicorn = "==19.9.0"
 pint = "==0.9"
 

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ IMAGE_COMMIT=$(git rev-parse --short HEAD)
 container=$(buildah from ${REGISTRY}/${PROJECT}/ingredient-phrase-tagger-wrapper:latest)
 buildah copy ${container} 'web' 'web'
 buildah copy ${container} 'Pipfile'
+buildah run ${container} -- apk add git
 buildah run ${container} -- pip install pipenv
 buildah run ${container} -- pipenv install
 buildah config --port 80 --entrypoint 'pipenv run gunicorn web.app:app --bind :80' ${container}

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -94,6 +94,7 @@ def test_request(client):
         'descriptions[]': [
             '100ml red wine',
             '1000 grams potatoes',
+            'pinch salt',
         ]
     })
 
@@ -116,6 +117,16 @@ def test_request(client):
         'units': 'g',
         'units_parser': 'ingreedypy+pint',
         'quantity': 1000,
+        'quantity_parser': 'ingreedypy+pint'
+    }, {
+        'description': 'pinch salt',
+        'product': {
+            'product': 'salt',
+            'product_parser': 'ingreedypy',
+        },
+        'units': 'ml',
+        'units_parser': 'ingreedypy+pint',
+        'quantity': 0.25,
         'quantity_parser': 'ingreedypy+pint'
     }]
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -43,6 +43,29 @@ def test_parse_description_ingreedypy(description, expected):
     assert result == expected
 
 
+def test_merge_ingredient_quantity_heuristic(sample_ingredient):
+    ingredient_a = sample_ingredient.copy()
+    ingredient_a.update({
+        'description': '12 units of ingredient',
+        'parser': 'a',
+        'quantity': 1,
+        'units': 'a'
+    })
+
+    ingredient_b = sample_ingredient.copy()
+    ingredient_b.update({
+        'description': '12 units of ingredient',
+        'parser': 'b',
+        'quantity': 12,
+        'units': 'b'
+    })
+
+    merged_ingredient = merge_ingredients(ingredient_a, ingredient_b)
+
+    assert merged_ingredient['quantity'] == 12
+    assert merged_ingredient['units'] == 'b'
+
+
 def test_merge_ingredient_unit_fallback(sample_ingredient):
     ingredient_a = sample_ingredient.copy()
     ingredient_a.update({

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -117,6 +117,7 @@ def test_request(client):
         'descriptions[]': [
             '100ml red wine',
             '1000 grams potatoes',
+            '2lb 4oz potatoes',
             'pinch salt',
         ]
     })
@@ -140,6 +141,16 @@ def test_request(client):
         'units': 'g',
         'units_parser': 'ingreedypy+pint',
         'quantity': 1000,
+        'quantity_parser': 'ingreedypy+pint'
+    }, {
+        'description': '2lb 4oz potatoes',
+        'product': {
+            'product': 'potatoes',
+            'product_parser': 'ingreedypy',
+        },
+        'units': 'g',
+        'units_parser': 'ingreedypy+pint',
+        'quantity': 907.18,
         'quantity_parser': 'ingreedypy+pint'
     }, {
         'description': 'pinch salt',

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -26,6 +26,11 @@ def parser_tests():
             'quantity': 1,
             'units': 'kilogram'
         },
+        '1kg/2lb 4oz potatoes, cut into 5cm/2in chunks': {
+            'product': 'potatoes, cut into 5cm/2in chunks',
+            'quantity': 1,
+            'units': 'kilogram'
+        },
     }
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -141,15 +141,13 @@ def merge_ingredients(a, b):
     a_quantity = (
         not contains(b, 'quantity') or contains(a, 'quantity')
         and a['quantity'] in re.findall('\\d+', description)
-    )
-    a_units = (
-        not contains(b, 'units') or contains(a, 'units')
+        and not b['quantity'] in re.findall('\\d+', description)
     )
 
     winners = {
         'product': a if a_product else b,
         'quantity': a if a_quantity else b,
-        'units': a if a_units else b,
+        'units': a if a_quantity else b,
     }
 
     ingredient = {'description': winners.values()[0]['description']}
@@ -158,9 +156,9 @@ def merge_ingredients(a, b):
         merge_field = merge_ingredient_field(winner, field)
         ingredient.update(merge_field)
 
-    units_field = parse_units(a if a_units else b)
+    units_field = parse_units(a if a_quantity else b)
     if not units_field:
-        units_field = parse_units(b if a_units else a)
+        units_field = parse_units(b if a_quantity else a)
     if units_field:
         ingredient.update(units_field)
 

--- a/web/app.py
+++ b/web/app.py
@@ -88,7 +88,7 @@ def parse_units(ingredient):
     # https://github.com/hgrecco/pint/issues/273
     if ingredient and ingredient.get('units') == 'pinch':
         ingredient['units'] = 'ml'
-        ingredient['quantity'] = ingredient.get('quantity', 1) * 0.25
+        ingredient['quantity'] = (ingredient.get('quantity') or 1) * 0.25
 
     try:
         quantity = unit_registry.Quantity(

--- a/web/app.py
+++ b/web/app.py
@@ -140,7 +140,7 @@ def merge_ingredients(a, b):
     )
     a_quantity = (
         not contains(b, 'quantity') or contains(a, 'quantity')
-        and a['quantity'] in re.findall('\d+', description)
+        and a['quantity'] in re.findall('\\d+', description)
     )
     a_units = (
         not contains(b, 'units') or contains(a, 'units')


### PR DESCRIPTION
Adds test coverage and pulls in https://github.com/openculinary/ingreedy-py/pull/4 in order to better parse ingredients containing containing alternative amount descriptors (such as `1kg/2lb`).