### PR TITLE
Include individual parser results in response

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 flask = "==1.1.1"
-ingreedypy = { git = "https://github.com/openculinary/ingreedy-py.git", ref = "f2573b4" }
+ingreedypy = { git = "https://github.com/openculinary/ingreedy-py.git", ref = "5135f7a" }
 gunicorn = "==19.9.0"
 pint = "==0.9"
 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,6 @@ IMAGE_COMMIT=$(git rev-parse --short HEAD)
 container=$(buildah from ${REGISTRY}/${PROJECT}/ingredient-phrase-tagger-wrapper:latest)
 buildah copy ${container} 'web' 'web'
 buildah copy ${container} 'Pipfile'
-buildah run ${container} -- apk add git
 buildah run ${container} -- pip install pipenv
 buildah run ${container} -- pipenv install
 buildah config --port 80 --entrypoint 'pipenv run gunicorn web.app:app --bind :80' ${container}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -92,6 +92,7 @@ def test_merge_ingredient_unit_fallback(sample_ingredient):
     })
 
     merged_ingredient = merge_ingredients(ingredient_a, ingredient_b)
+    del merged_ingredient['parsers']
 
     assert merged_ingredient == {
         'description': '1 block firm tofu',

--- a/web/app.py
+++ b/web/app.py
@@ -152,7 +152,10 @@ def merge_ingredients(a, b):
         'units': a if a_quantity else b,
     }
 
-    ingredient = {'description': winners.values()[0]['description']}
+    ingredient = {
+        'description': description,
+        'parsers': {v['parser']: v for v in [a, b] if v}
+    }
     for field in ['product', 'quantity', 'units']:
         winner = winners[field]
         merge_field = merge_ingredient_field(winner, field)


### PR DESCRIPTION
In some circumstances it can be hard to tell from the 'merged' ingredient parse results why an individual parser was chosen over another.

This change includes each parser's results in the output so that it's easier to determine how each fared when parsing an input text.