### PR TITLE
Reduce to single-parser implementation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,8 +11,10 @@ flask = "==1.1.1"
 gunicorn = "==19.9.0"
 ingreedypy = "==1.2"
 pint = "==0.9"
+requests = "==2.22.0"
 
 [dev-packages]
 flake8 = "*"
 mock = "*"
 pytest = "*"
+responses = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_version = "2.7"
+python_version = "3.7"
 
 [packages]
 flask = "==1.1.1"

--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,4 @@ pint = "==0.9"
 [dev-packages]
 flake8 = "*"
 mock = "*"
-pytest = "==4.6.5"
+pytest = "*"

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ SERVICE=$(basename `git rev-parse --show-toplevel`)
 IMAGE_NAME=${REGISTRY}/${PROJECT}/${SERVICE}
 IMAGE_COMMIT=$(git rev-parse --short HEAD)
 
-container=$(buildah from ${REGISTRY}/${PROJECT}/ingredient-phrase-tagger-wrapper:latest)
+container=$(buildah from docker.io/library/python:3.7-alpine)
 buildah copy ${container} 'web' 'web'
 buildah copy ${container} 'Pipfile'
 buildah run ${container} -- pip install pipenv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import responses
 
 from web.app import app
 
@@ -6,3 +7,14 @@ from web.app import app
 @pytest.fixture
 def client():
     return app.test_client()
+
+
+@pytest.fixture
+def knowledge_graph_stub():
+    with responses.RequestsMock() as response:
+        response.add(
+            responses.POST,
+            'http://knowledge-graph-service/ingredients/query',
+            status=500
+        )
+        yield response

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from web.app import (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,12 +39,10 @@ def test_parse_description(description, expected):
     expected.update({'product': {'product': expected['product']}})
 
     result = parse_description(description)
-
-    # TODO: These are response-format workarounds and should be removed
-    result = {k: v for k, v in result.items() if not k.endswith('_parser')}
     del result['product']['product_parser']
 
-    assert result == expected
+    for field in expected:
+        assert result[field] == expected[field]
 
 
 def unit_parser_tests():

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -28,7 +28,7 @@ def request_tests():
 
 
 @pytest.mark.parametrize('description,expected', request_tests())
-def test_request(client, description, expected):
+def test_request(client, knowledge_graph_stub, description, expected):
     response = client.post('/', data={'descriptions[]': description})
     ingredient = response.json[0]
 
@@ -37,7 +37,7 @@ def test_request(client, description, expected):
     assert ingredient['units'] == expected['units']
 
 
-def test_request_dimensionless(client):
+def test_request_dimensionless(client, knowledge_graph_stub):
     response = client.post('/', data={'descriptions[]': ['1 potato']})
     ingredient = response.json[0]
 
@@ -46,7 +46,7 @@ def test_request_dimensionless(client):
 
 
 @patch('web.app.parse_units')
-def test_request_unit_parse_failure(parse_units, client):
+def test_request_unit_parse_failure(parse_units, client, knowledge_graph_stub):
     parse_units.return_value = None
 
     response = client.post('/', data={'descriptions[]': ['100ml red wine']})

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -27,12 +27,7 @@ def request_tests():
     }.items()
 
 
-def nyt_parser_stub(descriptions):
-    return [{'input': description} for description in descriptions]
-
-
 @pytest.mark.parametrize('description,expected', request_tests())
-@patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
 def test_request(client, description, expected):
     response = client.post('/', data={'descriptions[]': description})
     ingredient = response.json[0]
@@ -42,18 +37,15 @@ def test_request(client, description, expected):
     assert ingredient['units'] == expected['units']
 
 
-@patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
 def test_request_dimensionless(client):
     response = client.post('/', data={'descriptions[]': ['1 potato']})
     ingredient = response.json[0]
 
     assert ingredient['product']['product'] == 'potato'
     assert ingredient['quantity'] == 1
-    assert 'units' not in ingredient
 
 
 @patch('web.app.parse_units')
-@patch('web.app.parse_descriptions_nyt', nyt_parser_stub)
 def test_request_unit_parse_failure(parse_units, client):
     parse_units.return_value = None
 

--- a/web/app.py
+++ b/web/app.py
@@ -1,24 +1,13 @@
 from flask import Flask, jsonify, request
 from fractions import Fraction
-import json
 from pint import UnitRegistry
-import re
 from unicodedata import numeric
-from subprocess import Popen, PIPE
 
 from ingreedypy import Ingreedy
 
 
 app = Flask(__name__)
 unit_registry = UnitRegistry()
-
-
-def parse_descriptions_nyt(descriptions):
-    env = {'PATH': '/usr/bin:/usr/local/bin', 'PYTHONPATH': '..'}
-    command = ['bin/parse-ingredients.py', '--model-file', 'model/latest']
-    parser = Popen(command, env=env, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    out, err = parser.communicate('\n'.join(descriptions))
-    return json.loads(out)
 
 
 def generate_subtexts(description):
@@ -32,7 +21,7 @@ def generate_subtexts(description):
     yield description.replace(',', '')
 
 
-def parse_description_ingreedypy(description):
+def parse_description(description):
     ingreedy = Ingreedy()
     ingredient = {}
     for text in generate_subtexts(description):
@@ -42,33 +31,21 @@ def parse_description_ingreedypy(description):
         except Exception:
             pass
 
-    return {
-        'parser': 'ingreedypy',
+    result = {
         'description': description,
-        'product': ingredient.get('ingredient'),
+        'product': {
+            'product': ingredient.get('ingredient'),
+            'product_parser': 'ingreedypy',
+        },
         'quantity': ingredient.get('amount'),
+        'quantity_parser': 'ingreedypy',
         'units': ingredient.get('unit'),
+        'units_parser': 'ingreedypy',
     }
-
-
-def parse_quantity(value):
-    if value is None:
-        return
-
-    try:
-        quantity = 0
-        fragments = value.split()
-        for fragment in fragments:
-            if len(fragment) == 1:
-                fragment = numeric(fragment)
-            elif fragment[-1].isdigit():
-                fragment = Fraction(fragment)
-            else:
-                fragment = Fraction(fragment[:-1]) + numeric(fragment[-1])
-            quantity += float(fragment)
-        return quantity
-    except Exception:
-        return None
+    units = parse_units(result)
+    if units:
+        result.update(units)
+    return result
 
 
 def get_base_units(quantity):
@@ -104,91 +81,24 @@ def parse_units(ingredient):
     if base_units:
         quantity = quantity.to(base_units)
 
-    result = {
-        'quantity': round(quantity.magnitude, 2),
-        'quantity_parser': ingredient['parser'] + '+pint'
-    }
-    result.update({
-        'units': base_units,
-        'units_parser': ingredient['parser'] + '+pint'
-    } if base_units else {})
+    result = {}
+    result['quantity'] = round(quantity.magnitude, 2)
+    if result.get('quantity_parser'):
+        result['quantity_parser'] += '+pint'
+    if base_units:
+        result['units'] = base_units
+        if result.get('units_parser'):
+            result['units_parser'] += '+pint'
     return result
-
-
-def merge_ingredient_field(winner, field):
-    if winner.get(field) is None:
-        return {}
-
-    nested_fields = {'product'}
-    parser = '{}_parser'.format(field)
-    ingredient = {
-        field: winner[field],
-        parser: winner['parser'] if winner[field] else None,
-    }
-    return {field: ingredient} if field in nested_fields else ingredient
-
-
-def contains(item, field):
-    if not item:
-        return False
-    return item.get(field) is not None
-
-
-def merge_ingredients(a, b):
-    description = (a or b).get('description')
-    a_product = (
-        not contains(b, 'product') or contains(a, 'product')
-        and len(a['product']) <= len(b['product'])
-    )
-    a_quantity = (
-        not contains(b, 'quantity') or contains(a, 'quantity')
-        and a['quantity'] in re.findall('\\d+', description)
-        and not b['quantity'] in re.findall('\\d+', description)
-    )
-
-    winners = {
-        'product': a if a_product else b,
-        'quantity': a if a_quantity else b,
-        'units': a if a_quantity else b,
-    }
-
-    ingredient = {
-        'description': description,
-        'parsers': {v['parser']: v for v in [a, b] if v}
-    }
-    for field in ['product', 'quantity', 'units']:
-        winner = winners[field]
-        merge_field = merge_ingredient_field(winner, field)
-        ingredient.update(merge_field)
-
-    units_field = parse_units(a if a_quantity else b)
-    if not units_field:
-        units_field = parse_units(b if a_quantity else a)
-    if units_field:
-        ingredient.update(units_field)
-
-    return ingredient
 
 
 @app.route('/', methods=['POST'])
 def root():
     descriptions = request.form.getlist('descriptions[]')
-    descriptions = [d.encode('utf-8') for d in descriptions]
     descriptions = [d.strip().lower() for d in descriptions]
 
-    nyt_ingredients = parse_descriptions_nyt(descriptions)
-    nyt_ingredients = [{
-        'parser': 'nyt',
-        'description': nyt_ingredient['input'],
-        'product': nyt_ingredient.get('name'),
-        'quantity': parse_quantity(nyt_ingredient.get('qty')),
-        'units': nyt_ingredient.get('unit'),
-    } for nyt_ingredient in nyt_ingredients]
-
     ingredients = []
-    for nyt_ingredient in nyt_ingredients:
-        description = nyt_ingredient['description']
-        igy_ingredient = parse_description_ingreedypy(description)
-        ingredient = merge_ingredients(nyt_ingredient, igy_ingredient)
+    for description in descriptions:
+        ingredient = parse_description(description)
         ingredients.append(ingredient)
     return jsonify(ingredients)

--- a/web/app.py
+++ b/web/app.py
@@ -1,7 +1,5 @@
 from flask import Flask, jsonify, request
-from fractions import Fraction
 from pint import UnitRegistry
-from unicodedata import numeric
 
 from ingreedypy import Ingreedy
 


### PR DESCRIPTION
Prior to this change, the `ingredient-parser` used a combination of the [ingreedy-py](https://www.github.com/openculinary/ingreedy-py) and `ingredient-phrase-tagger` ingredient parsers (the latter is incorporated into `ingredient-parser` as a base image by the [ingredient-phrase-tagger-wrapper](https://github.com/openculinary/ingredient-phrase-tagger-wrapper)).

This leads to complexity in determining a 'winning' parser, particularly across the different quantity, units and description fields present.

This changeset simplifies the service to use a single parser, `ingreedy-py`, which resolves #10 .

Quantity and unit parsing remains in the `ingredient-parser` codebase; it's possible this could be migrated to the knowledge graph in future.