### PR TITLE
Empty knowledge-graph results shouldn't clobber parsed product names

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -53,6 +53,7 @@ def test_knowledge_graph_query():
     descriptions_to_products = {
         'whole onion, diced': 'onion',
         'splash of tomato ketchup': 'tomato ketchup',
+        'plantains, peeled and chopped': None,
     }
 
     response = {'results': {d: p for d, p in descriptions_to_products.items()}}
@@ -65,10 +66,14 @@ def test_knowledge_graph_query():
     results = parse_descriptions(list(descriptions_to_products.keys()))
     for result in results:
         description = result['description']
-        expected_product = descriptions_to_products.get(description)
+        fixture_product = descriptions_to_products.get(description)
 
-        assert result['product']['product'] == expected_product
-        assert 'graph' in result['product']['product_parser']
+        if fixture_product is None:
+            assert result['product']['product'] == description
+            assert 'graph' not in result['product']['product_parser']
+        else:
+            assert result['product']['product'] == fixture_product
+            assert 'graph' in result['product']['product_parser']
 
 
 def unit_parser_tests():

--- a/web/app.py
+++ b/web/app.py
@@ -48,25 +48,25 @@ def parse_description(description):
 
 
 def parse_descriptions(descriptions):
-    ingredients_by_product = {}
+    ingredients_by_description = {}
     for description in descriptions:
         ingredient = parse_description(description)
         product = ingredient['product']['product']
-        ingredients_by_product[product] = ingredient
+        ingredients_by_description[product] = ingredient
 
     ingredient_data = requests.post(
         url='http://knowledge-graph-service/ingredients/query',
-        data={'descriptions[]': list(ingredients_by_product.keys())},
+        data={'descriptions[]': list(ingredients_by_description.keys())},
         proxies={}
     )
     if ingredient_data.ok:
         results = ingredient_data.json()['results']
         for product in results:
-            ingredient = ingredients_by_product[product]
+            ingredient = ingredients_by_description[product]
             ingredient['product']['product'] = results.get(product)
             ingredient['product']['product_parser'] += '+graph'
 
-    return list(ingredients_by_product.values())
+    return list(ingredients_by_description.values())
 
 
 def get_base_units(quantity):

--- a/web/app.py
+++ b/web/app.py
@@ -61,9 +61,11 @@ def parse_descriptions(descriptions):
     )
     if ingredient_data.ok:
         results = ingredient_data.json()['results']
-        for product in results:
-            ingredient = ingredients_by_description[product]
-            ingredient['product']['product'] = results.get(product)
+        for description in results:
+            if results[description] is None:
+                continue
+            ingredient = ingredients_by_description[description]
+            ingredient['product']['product'] = results.get(description)
             ingredient['product']['product_parser'] += '+graph'
 
     return list(ingredients_by_description.values())

--- a/web/app.py
+++ b/web/app.py
@@ -48,27 +48,27 @@ def parse_description(description):
 
 
 def parse_descriptions(descriptions):
-    ingredients_by_description = {}
+    ingredients_by_product = {}
     for description in descriptions:
         ingredient = parse_description(description)
         product = ingredient['product']['product']
-        ingredients_by_description[product] = ingredient
+        ingredients_by_product[product] = ingredient
 
     ingredient_data = requests.post(
         url='http://knowledge-graph-service/ingredients/query',
-        data={'descriptions[]': list(ingredients_by_description.keys())},
+        data={'descriptions[]': list(ingredients_by_product.keys())},
         proxies={}
     )
     if ingredient_data.ok:
         results = ingredient_data.json()['results']
-        for description in results:
-            if results[description] is None:
+        for product in results:
+            if results[product] is None:
                 continue
-            ingredient = ingredients_by_description[description]
-            ingredient['product']['product'] = results.get(description)
+            ingredient = ingredients_by_product[product]
+            ingredient['product']['product'] = results[product]
             ingredient['product']['product_parser'] += '+graph'
 
-    return list(ingredients_by_description.values())
+    return list(ingredients_by_product.values())
 
 
 def get_base_units(quantity):


### PR DESCRIPTION
Currently the `knowledge-graph` may return an empty `product` name if it's unable to find information about that product in the graph.

That's a valid response from the graph service, but we shouldn't allow the empty result to overwrite any initial parsing performed by the `ingredient-parser`.  It's likely not to have found an ideal match, but it's still better to allow the product (and therefore recipe) to parse given partial content than to return a completely empty result.