### PR TITLE
Update to ingreedypy==1.3.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
+ingreedypy = { git="https://github.com/openculinary/ingreedy-py.git", ref="support-multipart-quantities" }
 pint = "==0.9"
 requests = "==2.22.0"
 
@@ -17,8 +18,3 @@ flake8 = "*"
 mock = "*"
 pytest = "*"
 responses = "*"
-
-[packages.ingreedypy]
-git = "https://github.com/openculinary/ingreedy-py.git"
-editable = true
-ref = "support-multipart-quantities"

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
+ingreedypy = "==1.2.3"
 pint = "==0.9"
 requests = "==2.22.0"
 
@@ -17,8 +18,3 @@ flake8 = "*"
 mock = "*"
 pytest = "*"
 responses = "*"
-
-[packages.ingreedypy]
-git = "https://github.com/openculinary/ingreedy-py.git"
-editable = true
-ref = "support-multipart-quantities"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-ingreedypy = "==1.2.3"
+ingreedypy = "==1.3.0"
 pint = "==0.9"
 requests = "==2.22.0"
 

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-ingreedypy = "==1.2.3"
 pint = "==0.9"
 requests = "==2.22.0"
 
@@ -18,3 +17,8 @@ flake8 = "*"
 mock = "*"
 pytest = "*"
 responses = "*"
+
+[packages.ingreedypy]
+git = "https://github.com/openculinary/ingreedy-py.git"
+editable = true
+ref = "support-multipart-quantities"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-ingreedypy = { git="https://github.com/openculinary/ingreedy-py.git", ref="support-multipart-quantities" }
 pint = "==0.9"
 requests = "==2.22.0"
 
@@ -18,3 +17,8 @@ flake8 = "*"
 mock = "*"
 pytest = "*"
 responses = "*"
+
+[packages.ingreedypy]
+git = "https://github.com/openculinary/ingreedy-py.git"
+editable = true
+ref = "support-multipart-quantities"

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,6 @@ IMAGE_COMMIT=$(git rev-parse --short HEAD)
 container=$(buildah from docker.io/library/python:3.7-alpine)
 buildah copy ${container} 'web' 'web'
 buildah copy ${container} 'Pipfile'
-buildah run ${container} -- apk add git
 buildah run ${container} -- pip install pipenv
 buildah run ${container} -- pipenv install
 buildah config --port 80 --entrypoint 'pipenv run gunicorn web.app:app --bind :80' ${container}

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ IMAGE_COMMIT=$(git rev-parse --short HEAD)
 container=$(buildah from docker.io/library/python:3.7-alpine)
 buildah copy ${container} 'web' 'web'
 buildah copy ${container} 'Pipfile'
+buildah run ${container} -- apk add git
 buildah run ${container} -- pip install pipenv
 buildah run ${container} -- pipenv install
 buildah config --port 80 --entrypoint 'pipenv run gunicorn web.app:app --bind :80' ${container}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,7 @@ import json
 from web.app import (
     parse_description,
     parse_descriptions,
-    parse_units,
+    parse_quantities,
 )
 
 
@@ -83,16 +83,15 @@ def test_knowledge_graph_query():
 def unit_parser_tests():
     return {
         '0.25 ml': {
+            'quantity': [{'amount': 1, 'unit': 'pinch'}],
             'product': {'product': 'paprika'},
-            'quantity': 1,
-            'units': 'pinch',
         },
     }.items()
 
 
 @pytest.mark.parametrize('expected, ingredient', unit_parser_tests())
-def test_parse_units(expected, ingredient):
-    result = parse_units(ingredient)
-    result = '{} {}'.format(result['quantity'], result['units'])
+def test_parse_quantity(expected, ingredient):
+    quantity, units, parser = parse_quantities(ingredient)
+    result = '{} {}'.format(quantity, units)
 
     assert result == expected

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -16,7 +16,7 @@ def request_tests():
         },
         '2lb 4oz potatoes': {
             'product': 'potatoes',
-            'quantity': 907.18,
+            'quantity': 1020.58,
             'units': 'g',
         },
         'pinch salt': {
@@ -45,9 +45,9 @@ def test_request_dimensionless(client, knowledge_graph_stub):
     assert ingredient['quantity'] == 1
 
 
-@patch('web.app.parse_units')
-def test_request_unit_parse_failure(parse_units, client, knowledge_graph_stub):
-    parse_units.return_value = None
+@patch('web.app.parse_quantity')
+def test_parse_quantity_failure(parse_quantity, client, knowledge_graph_stub):
+    parse_quantity.return_value = None
 
     response = client.post('/', data={'descriptions[]': ['100ml red wine']})
     ingredient = response.json[0]


### PR DESCRIPTION
This dependency upgrade includes a breaking change: [ingreedypy](https://github.com/openculinary/ingreedy-py) now returns [lists of quantity elements](https://github.com/openculinary/ingreedy-py/pull/8).

This changeset aggregates the list of quantities and continues to use the existing [pint](https://github.com/hgrecco/pint) library dependency to convert the amounts into canonical units for storage and indexing.