### PR TITLE
Read 'markup' field from knowledge-graph query responses

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -49,16 +49,22 @@ def test_parse_description(description, expected):
 
 @responses.activate
 def test_knowledge_graph_query():
-    descriptions_to_products = {
-        'whole onion, diced': 'onion',
-        'splash of tomato ketchup': 'tomato ketchup',
+    description_responses = {
+        'whole onion, diced': {
+            'product': 'onion',
+            'markup': 'whole <mark>onion</mark> diced',
+        },
+        'splash of tomato ketchup': {
+            'product': 'tomato ketchup',
+            'markup': 'splash of <mark>tomato ketchup</mark>',
+        },
         'plantains, peeled and chopped': None,
     }
 
     response = {
         'results': {
-            d: {'product': p} if p else None
-            for d, p in descriptions_to_products.items()
+            d: r if r else None
+            for d, r in description_responses.items()
         }
     }
     responses.add(
@@ -67,16 +73,16 @@ def test_knowledge_graph_query():
         body=json.dumps(response),
     )
 
-    results = parse_descriptions(list(descriptions_to_products.keys()))
+    results = parse_descriptions(list(description_responses.keys()))
     for result in results:
         description = result['description']
-        fixture_product = descriptions_to_products.get(description)
+        response = description_responses.get(description)
 
-        if fixture_product is None:
+        if not response:
             assert result['product']['product'] == description
             assert 'graph' not in result['product']['product_parser']
         else:
-            assert result['product']['product'] == fixture_product
+            assert result['product']['product'] == response['product']
             assert 'graph' in result['product']['product_parser']
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -51,12 +51,12 @@ def test_parse_description(description, expected):
 def test_knowledge_graph_query():
     description_responses = {
         'whole onion, diced': {
-            'product': 'onion',
-            'markup': 'whole <mark>onion</mark> diced',
+            'product': {'product': 'onion'},
+            'query': {'markup': 'whole <mark>onion</mark> diced'},
         },
         'splash of tomato ketchup': {
-            'product': 'tomato ketchup',
-            'markup': 'splash of <mark>tomato ketchup</mark>',
+            'product': {'product': 'tomato ketchup'},
+            'query': {'markup': 'splash of <mark>tomato ketchup</mark>'},
         },
         'plantains, peeled and chopped': None,
     }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -85,7 +85,7 @@ def test_knowledge_graph_query():
         else:
             assert result['product']['product'] == response['product']
             assert 'graph' in result['product']['product_parser']
-            assert result['markup'] == response['markup']
+            assert result['markup'] == response['query']['markup']
 
 
 def unit_parser_tests():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -81,9 +81,11 @@ def test_knowledge_graph_query():
         if not response:
             assert result['product']['product'] == description
             assert 'graph' not in result['product']['product_parser']
+            assert result['markup'] == description
         else:
             assert result['product']['product'] == response['product']
             assert 'graph' in result['product']['product_parser']
+            assert result['markup'] == response['markup']
 
 
 def unit_parser_tests():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -76,16 +76,18 @@ def test_knowledge_graph_query():
     results = parse_descriptions(list(description_responses.keys()))
     for result in results:
         description = result['description']
+        markup = result['markup']
+        product = result['product']
         response = description_responses.get(description)
 
         if not response:
-            assert result['product']['product'] == description
+            assert markup == description
+            assert product['product'] == description
             assert 'graph' not in result['product']['product_parser']
-            assert result['markup'] == description
         else:
-            assert result['product']['product'] == response['product']['product']
-            assert 'graph' in result['product']['product_parser']
-            assert result['markup'] == response['query']['markup']
+            assert markup == response['query']['markup']
+            assert product['product'] == response['product']['product']
+            assert 'graph' in product['product_parser']
 
 
 def unit_parser_tests():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -83,7 +83,7 @@ def test_knowledge_graph_query():
             assert 'graph' not in result['product']['product_parser']
             assert result['markup'] == description
         else:
-            assert result['product']['product'] == response['product']
+            assert result['product']['product'] == response['product']['product']
             assert 'graph' in result['product']['product_parser']
             assert result['markup'] == response['query']['markup']
 

--- a/web/app.py
+++ b/web/app.py
@@ -105,9 +105,9 @@ def parse_descriptions(descriptions):
             if results[product] is None:
                 continue
             ingredient = ingredients_by_product[product]
+            ingredient['markup'] = results[product]['query']['markup']
             ingredient['product'] = results[product]['product']
             ingredient['product']['product_parser'] = 'knowledge-graph'
-            ingredient['markup'] = results[product]['query']['markup']
 
     return list(ingredients_by_product.values())
 

--- a/web/app.py
+++ b/web/app.py
@@ -107,7 +107,7 @@ def parse_descriptions(descriptions):
             ingredient = ingredients_by_product[product]
             ingredient['product'] = results[product]
             ingredient['product']['product_parser'] = 'knowledge-graph'
-            ingredient['markup'] = ingredient['product'].pop('markup')
+            ingredient['markup'] = results[product]['query']['markup']
 
     return list(ingredients_by_product.values())
 

--- a/web/app.py
+++ b/web/app.py
@@ -76,6 +76,7 @@ def parse_description(description):
     return {
         'description': description,
         'product': product,
+        'markup': parsed_product or description,
         'quantity': quantity,
         'quantity_parser': parser,
         'units': units,
@@ -106,6 +107,7 @@ def parse_descriptions(descriptions):
             ingredient = ingredients_by_product[product]
             ingredient['product'] = results[product]
             ingredient['product']['product_parser'] = 'knowledge-graph'
+            ingredient['markup'] = ingredient['product'].pop('markup')
 
     return list(ingredients_by_product.values())
 

--- a/web/app.py
+++ b/web/app.py
@@ -105,7 +105,7 @@ def parse_descriptions(descriptions):
             if results[product] is None:
                 continue
             ingredient = ingredients_by_product[product]
-            ingredient['product'] = results[product]
+            ingredient['product'] = results[product]['product']
             ingredient['product']['product_parser'] = 'knowledge-graph'
             ingredient['markup'] = results[product]['query']['markup']
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change read the `markup` field from `knowledge-graph` query responses, and in turn makes it available for the [API](https://github.com/openculinary/api) service to read and store at an ingredient-level.

The description of an individual product -- for example, `garlic` -- varies across different recipes.  Some recipes may add preparation details (`finely chopped`, `pressed`, ...), and therefore the `description` and `markup` fields should be stored by [RecipeIngredient](https://github.com/openculinary/api/blob/116a7c8d78f97c401ce4dfe318734101f200c02a/reciperadar/models/recipes/ingredient.py#L14) objects and not [IngredientProduct](https://github.com/openculinary/api/blob/116a7c8d78f97c401ce4dfe318734101f200c02a/reciperadar/models/recipes/product.py#L12) objects in the API.  In future, `IngredientProduct` references may be replaced with a singleton `Product` object for each known product.

### How have the changes been tested?
1. Unit tests are included

**List any issues that this change relates to**
This code can be cleaned up once https://github.com/openculinary/knowledge-graph/issues/34 is merged and available.

In particular, once https://github.com/openculinary/knowledge-graph/issues/34 is resolved, it should not be necessary to 'move' the `markup` response field into another dictionary; instead it will not be present in the `product` details and will be readable from another `knowledge-graph` response field.