### PR TITLE
Render ingredient markup in RecipeML

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -79,7 +79,7 @@ def test_knowledge_graph_query():
     results = parse_descriptions(list(description_responses.keys()))
     for result in results:
         description = result['description']
-        markup = result['markup']
+        markup = result['markup'].replace('ingredient>', 'mark>')
         product = result['product']
         response = description_responses.get(description)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -58,7 +58,10 @@ def test_knowledge_graph_query():
             'product': {'product': 'tomato ketchup'},
             'query': {'markup': 'splash of <mark>tomato ketchup</mark>'},
         },
-        'plantains, peeled and chopped': None,
+        'plantains, peeled and chopped': {
+            'product': {'product': 'plantains, peeled and chopped'},
+            'query': {'markup': '<mark>plantains, peeled and chopped</mark>'},
+        },
     }
 
     response = {

--- a/tests/test_recipeml.py
+++ b/tests/test_recipeml.py
@@ -11,8 +11,7 @@ def recipeml_tests():
         },
         'potatoes au gratin': {
             'markup': '<mark>potatoes</mark> au gratin',
-            'units': 'g',
-            'quantity': 500,
+            'quantity': 5,
         },
         'firm tofu': {
             'markup': '<mark>firm tofu</mark>',
@@ -21,8 +20,7 @@ def recipeml_tests():
         },
         'pinch salt': {
             'markup': 'pinch of <mark>salt</mark>',
-            'units': 'ml',
-            'quantity': 0.25,
+            'units': 'pinch',
         },
     }.items()
 
@@ -30,10 +28,13 @@ def recipeml_tests():
 def expected_markup(ingredient):
     markup, quantity, units = (
         ingredient['markup'],
-        ingredient['quantity'],
-        ingredient['units'],
+        ingredient.get('quantity'),
+        ingredient.get('units'),
     )
-    amount_markup = f'<amt><qty>{quantity}</qty><unit>{units}</unit></amt>'
+    amount_markup = f'<amt>'
+    amount_markup += f'<qty>{quantity}</qty>' if quantity else ''
+    amount_markup += f'<unit>{units}</unit>' if units else ''
+    amount_markup += f'</amt>'
     ingredient_markup = markup.replace('mark>', 'ingredient>')
     return amount_markup + ingredient_markup
 
@@ -43,7 +44,7 @@ def test_request(_, ingredient):
     expected = expected_markup(ingredient)
     result = merge(
         ingredient_markup=ingredient['markup'],
-        quantity=ingredient['quantity'],
-        units=ingredient['units']
+        quantity=ingredient.get('quantity'),
+        units=ingredient.get('units')
     )
     assert result == expected

--- a/tests/test_recipeml.py
+++ b/tests/test_recipeml.py
@@ -1,0 +1,49 @@
+import pytest
+from web.recipeml import merge
+
+
+def recipeml_tests():
+    return {
+        'red wine': {
+            'markup': '<mark>red wine</mark>',
+            'quantity': 100,
+            'units': 'ml',
+        },
+        'potatoes au gratin': {
+            'markup': '<mark>potatoes</mark> au gratin',
+            'units': 'g',
+            'quantity': 500,
+        },
+        'firm tofu': {
+            'markup': '<mark>firm tofu</mark>',
+            'quantity': 1,
+            'units': 'block',
+        },
+        'pinch salt': {
+            'markup': 'pinch of <mark>salt</mark>',
+            'units': 'ml',
+            'quantity': 0.25,
+        },
+    }.items()
+
+
+def expected_markup(ingredient):
+    markup, quantity, units = (
+        ingredient['markup'],
+        ingredient['quantity'],
+        ingredient['units'],
+    )
+    amount_markup = f'<amt><qty>{quantity}</qty><unit>{units}</unit></amt>'
+    ingredient_markup = markup.replace('mark>', 'ingredient>')
+    return amount_markup + ingredient_markup
+
+
+@pytest.mark.parametrize('_, ingredient', recipeml_tests())
+def test_request(_, ingredient):
+    expected = expected_markup(ingredient)
+    result = merge(
+        ingredient_markup=ingredient['markup'],
+        quantity=ingredient['quantity'],
+        units=ingredient['units']
+    )
+    assert result == expected

--- a/web/app.py
+++ b/web/app.py
@@ -4,6 +4,8 @@ import requests
 
 from ingreedypy import Ingreedy
 
+from web.recipeml import merge
+
 
 app = Flask(__name__)
 unit_registry = UnitRegistry()
@@ -112,6 +114,12 @@ def parse_descriptions(descriptions):
             ingredient['product'] = results[product]['product']
             ingredient['product']['product_parser'] = 'knowledge-graph'
 
+    for product, ingredient in ingredients_by_product.items():
+        ingredients_by_product[product]['markup'] = merge(
+            ingredient_markup=ingredient['markup'],
+            quantity=ingredient['quantity'],
+            units=ingredient['units'],
+        )
     return list(ingredients_by_product.values())
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -58,25 +58,28 @@ def parse_quantities(ingredient):
 
 
 def parse_description(description):
-    ingredient = {}
+    product = description
+    quantity = None
+    units = None
+    parser = None
+
     for text in generate_subtexts(description):
         try:
             ingredient = Ingreedy().parse(text)
+            product = ingredient['ingredient']
+            product_parser = 'ingreedypy'
+            quantity, units, parser = parse_quantities(ingredient)
             break
         except Exception:
             continue
 
-    parsed_product = ingredient.get('ingredient')
-    product = {
-        'product': parsed_product or description,
-        'product_parser': 'ingreedypy' if parsed_product else None,
-    }
-
-    quantity, units, parser = parse_quantities(ingredient)
     return {
         'description': description,
-        'product': product,
-        'markup': parsed_product or description,
+        'product': {
+            'product': product,
+            'product_parser': product_parser,
+        },
+        'markup': f'<mark>{product}</mark>',
         'quantity': quantity,
         'quantity_parser': parser,
         'units': units,

--- a/web/recipeml.py
+++ b/web/recipeml.py
@@ -1,10 +1,21 @@
 import xml.etree.ElementTree as ET
 
 
+def inner_xml(element):
+    return (element.text or '') + ''.join([
+        ET.tostring(subelement, 'unicode')
+        for subelement in element
+    ])
+
+
 def merge(ingredient_markup, quantity, units):
-    print(ingredient_markup)
-    doc = ET.fromstring(f'<root>{ingredient_markup}</root>')
-    print(ET.tostring(doc))
-    for element in doc.iter('mark'):
+    ingredient = ET.fromstring(f'<root>{ingredient_markup}</root>')
+    for element in ingredient.iter('mark'):
         element.tag = 'ingredient'
-    return ET.tostring(doc)
+    ingredient = inner_xml(ingredient)
+
+    amt = f'<qty>{quantity}</qty>' if quantity else ''
+    amt += f'<unit>{units}</unit>' if units else ''
+    amt = f'<amt>{amt}</amt>' if amt else ''
+
+    return amt + ingredient

--- a/web/recipeml.py
+++ b/web/recipeml.py
@@ -1,0 +1,10 @@
+import xml.etree.ElementTree as ET
+
+
+def merge(ingredient_markup, quantity, units):
+    print(ingredient_markup)
+    doc = ET.fromstring(f'<root>{ingredient_markup}</root>')
+    print(ET.tostring(doc))
+    for element in doc.iter('mark'):
+        element.tag = 'ingredient'
+    return ET.tostring(doc)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Rendering ingredient description lines in some form of XML markup makes sense, since it can interpolate text and markup elements.

Since [RecipeML](http://www.formatdata.com/recipeml/spec/recipeml-spec.html) exists an existing XML specification in the domain of recipes, and supports all of the entities we are currently interested in (and more for future), it makes sense to re-use this existing format.

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Relates to https://github.com/openculinary/knowledge-graph/pull/27