### PR TITLE
Temporarily remap product.id -> product.product_id

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,7 +38,10 @@ def ingredient_parser_tests():
 @pytest.mark.parametrize('description, expected', ingredient_parser_tests())
 def test_parse_description(description, expected):
     expected.update({'description': description})
-    expected.update({'product': {'product': expected['product']}})
+    expected.update({'product': {
+        'product': expected['product'],
+        'product_id': None}
+    })
 
     result = parse_description(description)
     del result['product']['product_parser']

--- a/web/app.py
+++ b/web/app.py
@@ -78,6 +78,7 @@ def parse_description(description):
     return {
         'description': description,
         'product': {
+            'product_id': None,
             'product': product,
             'product_parser': product_parser,
         },
@@ -113,6 +114,11 @@ def parse_descriptions(descriptions):
             ingredient['markup'] = results[product]['query']['markup']
             ingredient['product'] = results[product]['product']
             ingredient['product']['product_parser'] = 'knowledge-graph'
+
+            # TODO: Remove this remapping once the database handles native IDs
+            if 'id' in ingredient['product']:
+                ingredient['product']['product_id'] = \
+                    ingredient['product'].pop('id')
 
     for product, ingredient in ingredients_by_product.items():
         ingredients_by_product[product]['markup'] = merge(


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Unfortunately the `IngredientProduct.id` field in the application's backend service database isn't yet ready to store the native product identifiers used by the `knowledge-graph`.

Until then, we can remap this field to a less-ambiguous `product_id` field name, and store it in a similarly named column in the database.

### Briefly summarize the changes
1. Remap `product.id` -> `product.product_id` in `ingredient-parser` responses

### How have the changes been tested?
1. Manual inspection