### PR TITLE
Refactor: improve consistency for quantity/magnitude property naming

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,22 +14,22 @@ def ingredient_parser_tests():
     return {
         'tomato': {
             'product': 'tomato',
-            'quantity': None,
+            'magnitude': None,
             'units': None
         },
         '1 kilogram beef': {
             'product': 'beef',
-            'quantity': 1000,
+            'magnitude': 1000,
             'units': 'g'
         },
         '1kg/2lb 4oz potatoes, cut into 5cm/2in chunks': {
             'product': 'potatoes, cut into 5cm/2in chunks',
-            'quantity': 1000,
+            'magnitude': 1000,
             'units': 'g'
         },
         '1-½ ounce, weight vanilla ice cream': {
             'product': 'weight vanilla ice cream',
-            'quantity': 42.52,
+            'magnitude': 42.52,
             'units': 'g'
         },
     }.items()

--- a/tests/test_recipeml.py
+++ b/tests/test_recipeml.py
@@ -6,16 +6,16 @@ def recipeml_tests():
     return {
         'red wine': {
             'markup': '<mark>red wine</mark>',
-            'quantity': 100,
+            'magnitude': 100,
             'units': 'ml',
         },
         'potatoes au gratin': {
             'markup': '<mark>potatoes</mark> au gratin',
-            'quantity': 5,
+            'magnitude': 5,
         },
         'firm tofu': {
             'markup': '<mark>firm tofu</mark>',
-            'quantity': 1,
+            'magnitude': 1,
             'units': 'block',
         },
         'pinch salt': {
@@ -26,13 +26,13 @@ def recipeml_tests():
 
 
 def expected_markup(ingredient):
-    markup, quantity, units = (
+    markup, magnitude, units = (
         ingredient['markup'],
-        ingredient.get('quantity'),
+        ingredient.get('magnitude'),
         ingredient.get('units'),
     )
     amount_markup = '<amt>'
-    amount_markup += f'<qty>{quantity}</qty>' if quantity else ''
+    amount_markup += f'<qty>{magnitude}</qty>' if magnitude else ''
     amount_markup += f'<unit>{units}</unit>' if units else ''
     amount_markup += '</amt>'
     ingredient_markup = markup.replace('mark>', 'ingredient>')
@@ -44,7 +44,7 @@ def test_request(_, ingredient):
     expected = expected_markup(ingredient)
     result = merge(
         ingredient_markup=ingredient['markup'],
-        quantity=ingredient.get('quantity'),
+        magnitude=ingredient.get('magnitude'),
         units=ingredient.get('units')
     )
     assert result == expected
@@ -52,9 +52,9 @@ def test_request(_, ingredient):
 
 def test_entity_escaping():
     markup = '&amp; <mark>example</mark>'
-    quantity = 1
+    magnitude = 1
 
     expected = '<amt><qty>1</qty></amt>&amp; <ingredient>example</ingredient>'
-    result = merge(markup, quantity, None)
+    result = merge(markup, magnitude, None)
 
     assert result == expected

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -6,23 +6,23 @@ def request_tests():
     return {
         '100ml red wine': {
             'product': 'red wine',
-            'quantity': 100,
+            'magnitude': 100,
             'units': 'ml',
         },
         '1000 grams potatoes': {
             'product': 'potatoes',
+            'magnitude': 1000,
             'units': 'g',
-            'quantity': 1000,
         },
         '2lb 4oz potatoes': {
             'product': 'potatoes',
-            'quantity': 1020.58,
+            'magnitude': 1020.58,
             'units': 'g',
         },
         'pinch salt': {
             'product': 'salt',
+            'magnitude': 0.25,
             'units': 'ml',
-            'quantity': 0.25,
         },
     }.items()
 
@@ -33,7 +33,7 @@ def test_request(client, knowledge_graph_stub, description, expected):
     ingredient = response.json[0]
 
     assert ingredient['product']['product'] == expected['product']
-    assert ingredient['quantity'] == expected['quantity']
+    assert ingredient['magnitude'] == expected['magnitude']
     assert ingredient['units'] == expected['units']
 
 
@@ -42,7 +42,7 @@ def test_request_dimensionless(client, knowledge_graph_stub):
     ingredient = response.json[0]
 
     assert ingredient['product']['product'] == 'potato'
-    assert ingredient['quantity'] == 1
+    assert ingredient['magnitude'] == 1
 
 
 @patch('web.app.parse_quantity')
@@ -52,5 +52,5 @@ def test_parse_quantity_failure(parse_quantity, client, knowledge_graph_stub):
     response = client.post('/', data={'descriptions[]': ['100ml red wine']})
     ingredient = response.json[0]
 
-    assert 'pint' not in ingredient['quantity_parser']
+    assert 'pint' not in ingredient['magnitude_parser']
     assert 'pint' not in ingredient['units_parser']

--- a/web/app.py
+++ b/web/app.py
@@ -62,7 +62,7 @@ def parse_quantities(ingredient):
 def parse_description(description):
     product = description
     product_parser = None
-    quantity = None
+    magnitude = None
     units = None
     parser = None
 
@@ -71,7 +71,7 @@ def parse_description(description):
             ingredient = Ingreedy().parse(text)
             product = ingredient['ingredient']
             product_parser = 'ingreedypy'
-            quantity, units, parser = parse_quantities(ingredient)
+            magnitude, units, parser = parse_quantities(ingredient)
             break
         except Exception:
             continue
@@ -84,8 +84,8 @@ def parse_description(description):
             'product_parser': product_parser,
         },
         'markup': f'<mark>{product}</mark>',
-        'quantity': quantity,
-        'quantity_parser': parser,
+        'magnitude': magnitude,
+        'magnitude_parser': parser,
         'units': units,
         'units_parser': parser,
     }
@@ -124,7 +124,7 @@ def parse_descriptions(descriptions):
     for product, ingredient in ingredients_by_product.items():
         ingredients_by_product[product]['markup'] = merge(
             ingredient_markup=ingredient['markup'],
-            quantity=ingredient['quantity'],
+            magnitude=ingredient['magnitude'],
             units=ingredient['units'],
         )
     return list(ingredients_by_product.values())

--- a/web/recipeml.py
+++ b/web/recipeml.py
@@ -9,13 +9,13 @@ def inner_xml(element):
     ])
 
 
-def merge(ingredient_markup, quantity, units):
+def merge(ingredient_markup, magnitude, units):
     ingredient = ET.fromstring(f'<root>{ingredient_markup}</root>')
     for element in ingredient.iter('mark'):
         element.tag = 'ingredient'
     ingredient = inner_xml(ingredient)
 
-    amt = f'<qty>{quantity}</qty>' if quantity else ''
+    amt = f'<qty>{magnitude}</qty>' if magnitude else ''
     amt += f'<unit>{units}</unit>' if units else ''
     amt = f'<amt>{amt}</amt>' if amt else ''
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a minor terminology consistency change; throughout the application's codebase, a `quantity` object should consist of a `magnitude` field and a `units` field.