### PR TITLE
Render scaled ingredient nutritional metadata

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -90,14 +90,10 @@ def test_knowledge_graph_query():
                 'nutrition': None
             },
             'query': {'markup': '<mark>plantains, peeled and chopped</mark>'},
-            'units': None,
-            'magnitude': None,
         },
         'unknown': {
             'product': {'product': 'unknown'},
             'query': {'markup': '<mark>unknown</mark>'},
-            'units': None,
-            'magnitude': None,
         },
     }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -85,10 +85,7 @@ def test_knowledge_graph_query():
             'magnitude': 3.0,
         },
         'plantains, peeled and chopped': {
-            'product': {
-                'product': 'plantains, peeled and chopped',
-                'nutrition': None
-            },
+            'product': {'product': 'plantains, peeled and chopped'},
             'query': {'markup': '<mark>plantains, peeled and chopped</mark>'},
         },
         'unknown': {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -84,6 +84,21 @@ def test_knowledge_graph_query():
             'units': 'ml',
             'magnitude': 3.0,
         },
+        'chunk of butter': {
+            'product': {
+                'product': 'butter',
+                'nutrition': {
+                    'protein': 0.5,
+                    'fat': 82.0,
+                    'carbohydrates': 0.5,
+                    'energy': 745.0,
+                    'fibre': 0.0,
+                }
+            },
+            'query': {'markup': 'chunk of <mark>butter</mark>'},
+            'units': 'ml',
+            'magnitude': 25.0,
+        },
         'plantains, peeled and chopped': {
             'product': {'product': 'plantains, peeled and chopped'},
             'query': {'markup': '<mark>plantains, peeled and chopped</mark>'},
@@ -109,6 +124,13 @@ def test_knowledge_graph_query():
             'energy': 3.45,
             'fibre': 0.03,
         },
+        'chunk of butter': {
+            'protein': round(0.5 * 0.911 / 4, 2),
+            'fat': round(82.0 * 0.911 / 4, 2),
+            'carbohydrates': round(0.5 * 0.911 / 4, 2),
+            'energy': round(745.0 * 0.911 / 4, 2),
+            'fibre': round(0.0 * 0.911 / 4, 2),
+        }
     }
 
     responses.add(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,6 +7,7 @@ from web.app import (
     parse_description,
     parse_descriptions,
     parse_quantities,
+    retrieve_knowledge,
 )
 
 
@@ -104,7 +105,10 @@ def test_knowledge_graph_query():
         body=json.dumps(response),
     )
 
-    results = parse_descriptions(list(description_responses.keys()))
+    descriptions = list(description_responses.keys())
+    ingredients_by_product = parse_descriptions(descriptions)
+    results = retrieve_knowledge(ingredients_by_product)
+
     for result in results:
         description = result['description']
         markup = result['markup'].replace('ingredient>', 'mark>')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -109,6 +109,7 @@ def test_knowledge_graph_query():
         description = result['description']
         markup = result['markup'].replace('ingredient>', 'mark>')
         product = result['product']
+        nutrition = result['nutrition']
         response = description_responses.get(description)
 
         if not response['product']:
@@ -119,6 +120,7 @@ def test_knowledge_graph_query():
             assert markup == response['query']['markup']
             assert product['product'] == response['product']['product']
             assert 'graph' in product['product_parser']
+            assert nutrition == response['product']['nutrition']
 
 
 def unit_parser_tests():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,6 +94,23 @@ def test_knowledge_graph_query():
         },
     }
 
+    expected_nutrition = {
+        'whole onion, diced': {
+            'protein': 16.5,
+            'fat': 0.11,
+            'carbohydrates': 8.8,
+            'energy': 38.5,
+            'fibre': 2.2,
+        },
+        'splash of tomato ketchup': {
+            'protein': 0.04,
+            'fat': 0.0,
+            'carbohydrates': 0.85,
+            'energy': 3.45,
+            'fibre': 0.03,
+        },
+    }
+
     responses.add(
         responses.POST,
         'http://knowledge-graph-service/ingredients/query',
@@ -104,12 +121,14 @@ def test_knowledge_graph_query():
 
     for description, ingredient in results.items():
         product = ingredient['product']
-        nutrition = ingredient['nutrition']
-        response = knowledge[description]
+        product_expected = knowledge[description]['product']['product']
 
-        assert product['product'] == response['product']['product']
+        nutrition = ingredient['nutrition']
+        nutrition_expected = expected_nutrition.get(description)
+
+        assert product['product'] == product_expected
         assert 'graph' in product['product_parser']
-        assert nutrition == response['product'].get('nutrition', nutrition)
+        assert nutrition == nutrition_expected
 
 
 def unit_parser_tests():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,15 +54,36 @@ def test_parse_description(description, expected):
 def test_knowledge_graph_query():
     description_responses = {
         'whole onion, diced': {
-            'product': {'product': 'onion'},
+            'product': {
+                'product': 'onion',
+                'nutrition': {
+                    'protein': 15.0,
+                    'fat': 0.1,
+                    'carbohydrates': 8.0,
+                    'energy': 35.0,
+                    'fibre': 2.0,
+                }
+            },
             'query': {'markup': 'whole <mark>onion</mark> diced'},
         },
         'splash of tomato ketchup': {
-            'product': {'product': 'tomato ketchup'},
+            'product': {
+                'product': 'tomato ketchup',
+                'nutrition': {
+                    'protein': 1.5,
+                    'fat': 0.1,
+                    'carbohydrates': 28.5,
+                    'energy': 115.0,
+                    'fibre': 1.0,
+                }
+            },
             'query': {'markup': 'splash of <mark>tomato ketchup</mark>'},
         },
         'plantains, peeled and chopped': {
-            'product': {'product': 'plantains, peeled and chopped'},
+            'product': {
+                'product': 'plantains, peeled and chopped',
+                'nutrition': None
+            },
             'query': {'markup': '<mark>plantains, peeled and chopped</mark>'},
         },
         'unknown': {

--- a/web/app.py
+++ b/web/app.py
@@ -87,6 +87,23 @@ def parse_description(description):
     }
 
 
+def determine_density_ratio(product):
+    ratio = 1.0
+    if 'flour' in product:
+        ratio = 0.593
+    elif 'sugar' in product:
+        ratio = 0.850
+    elif 'milk' in product:
+        ratio = 1.030
+    elif 'cream' in product:
+        ratio = 1.010
+    elif 'oil' in product:
+        ratio = 0.900
+    elif 'butter' in product:
+        ratio = 0.911
+    return ratio
+
+
 def determine_nutritional_content(ingredient):
     nutrition = ingredient['product'].pop('nutrition', None)
     if not nutrition:
@@ -100,7 +117,8 @@ def determine_nutritional_content(ingredient):
         grams = ingredient['magnitude']
     elif ingredient['units'] == 'ml':
         # convert to grams based on density
-        grams = ingredient['magnitude']
+        ratio = determine_density_ratio(ingredient['product']['product'])
+        grams = ingredient['magnitude'] * ratio
     else:
         raise Exception(f"Unknown unit type: {ingredient['units']}")
 

--- a/web/app.py
+++ b/web/app.py
@@ -95,21 +95,21 @@ def determine_nutritional_content(ingredient):
         return None
     if not ingredient.get('units'):
         return None
+
     if ingredient['units'] == 'g':
-        # perform scaling
-        for nutrient, quantity in nutrition.items():
-            ratio = ingredient['magnitude'] / 100.0
-            scaled_quantity = quantity * ratio
-            nutrition[nutrient] = round(scaled_quantity, 2)
-        return nutrition
-    if ingredient['units'] == 'ml':
+        grams = ingredient['magnitude']
+    elif ingredient['units'] == 'ml':
         # convert to grams based on density
-        for nutrient, quantity in nutrition.items():
-            ratio = ingredient['magnitude'] / 100.0
-            scaled_quantity = quantity * ratio
-            nutrition[nutrient] = round(scaled_quantity, 2)
-        return nutrition
-    raise Exception(f"Unknown unit type: {ingredient['units']}")
+        grams = ingredient['magnitude']
+    else:
+        raise Exception(f"Unknown unit type: {ingredient['units']}")
+
+    # perform scaling
+    for nutrient, quantity in nutrition.items():
+        ratio = grams / 100.0
+        scaled_quantity = quantity * ratio
+        nutrition[nutrient] = round(scaled_quantity, 2)
+    return nutrition
 
 
 def parse_descriptions(descriptions):

--- a/web/app.py
+++ b/web/app.py
@@ -99,9 +99,13 @@ def determine_nutritional_content(ingredient):
         return None
     if ingredient['units'] == 'g':
         # perform scaling
+        for nutrient, quantity in nutrition.items():
+            nutrition[nutrient] = quantity
         return nutrition
     if ingredient['units'] == 'ml':
         # convert to grams based on density
+        for nutrient, quantity in nutrition.items():
+            nutrition[nutrient] = quantity
         return nutrition
     raise Exception(f"Unknown unit type: {ingredient['units']}")
 

--- a/web/app.py
+++ b/web/app.py
@@ -83,6 +83,7 @@ def parse_description(description):
             'product': product,
             'product_parser': product_parser,
         },
+        'nutrition': None,
         'markup': f'<mark>{product}</mark>',
         'magnitude': magnitude,
         'magnitude_parser': parser,
@@ -115,6 +116,8 @@ def parse_descriptions(descriptions):
             ingredient['markup'] = results[product]['query']['markup']
             ingredient['product'] = results[product]['product']
             ingredient['product']['product_parser'] = 'knowledge-graph'
+
+            ingredient['nutrition'] = ingredient['product'].pop('nutrition')
 
             # TODO: Remove this remapping once the database handles native IDs
             if 'id' in ingredient['product']:

--- a/web/app.py
+++ b/web/app.py
@@ -91,17 +91,23 @@ def determine_nutritional_content(ingredient):
     nutrition = ingredient['product'].pop('nutrition', None)
     if not nutrition:
         return None
+    if not ingredient.get('magnitude'):
+        return None
     if not ingredient.get('units'):
         return None
     if ingredient['units'] == 'g':
         # perform scaling
         for nutrient, quantity in nutrition.items():
-            nutrition[nutrient] = quantity
+            ratio = ingredient['magnitude'] / 100.0
+            scaled_quantity = quantity * ratio
+            nutrition[nutrient] = round(scaled_quantity, 2)
         return nutrition
     if ingredient['units'] == 'ml':
         # convert to grams based on density
         for nutrient, quantity in nutrition.items():
-            nutrition[nutrient] = quantity
+            ratio = ingredient['magnitude'] / 100.0
+            scaled_quantity = quantity * ratio
+            nutrition[nutrient] = round(scaled_quantity, 2)
         return nutrition
     raise Exception(f"Unknown unit type: {ingredient['units']}")
 

--- a/web/app.py
+++ b/web/app.py
@@ -122,7 +122,6 @@ def determine_nutritional_content(ingredient):
     else:
         raise Exception(f"Unknown unit type: {ingredient['units']}")
 
-    # perform scaling
     for nutrient, quantity in nutrition.items():
         ratio = grams / 100.0
         scaled_quantity = quantity * ratio

--- a/web/app.py
+++ b/web/app.py
@@ -105,7 +105,10 @@ def parse_descriptions(descriptions):
             raise Exception(f'Parsing failed: "{description}" - {e}')
         product = ingredient['product']['product']
         ingredients_by_product[product] = ingredient
+    return ingredients_by_product
 
+
+def retrieve_knowledge(ingredients_by_product):
     ingredient_data = requests.post(
         url='http://knowledge-graph-service/ingredients/query',
         data={'descriptions[]': list(ingredients_by_product.keys())},
@@ -161,6 +164,7 @@ def root():
     descriptions = request.form.getlist('descriptions[]')
     descriptions = [d.strip() for d in descriptions]
 
-    ingredients = parse_descriptions(descriptions)
+    ingredients_by_product = parse_descriptions(descriptions)
+    ingredients = retrieve_knowledge(ingredients_by_product)
 
     return jsonify(ingredients)

--- a/web/app.py
+++ b/web/app.py
@@ -92,6 +92,10 @@ def parse_description(description):
     }
 
 
+def determine_nutritional_content(ingredient, nutrition):
+    return nutrition
+
+
 def parse_descriptions(descriptions):
     ingredients_by_product = {}
     for description in descriptions:
@@ -117,7 +121,12 @@ def parse_descriptions(descriptions):
             ingredient['product'] = results[product]['product']
             ingredient['product']['product_parser'] = 'knowledge-graph'
 
-            ingredient['nutrition'] = ingredient['product'].pop('nutrition')
+            nutrition = ingredient['product'].pop('nutrition')
+            if nutrition:
+                ingredient['nutrition'] = determine_nutritional_content(
+                    ingredient=ingredient,
+                    nutrition=nutrition
+                )
 
             # TODO: Remove this remapping once the database handles native IDs
             if 'id' in ingredient['product']:


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
With openculinary/knowledge-graph#49 merged, we receive nutritional metadata alongside the product information returned by the knowledge graph in response to ingredient text queries.

This changeset makes use of that metadata by scaling the nutrient information from the knowledge graph -- which is standardized as per-100g measurements -- to match the ingredient quantities identified by `ingreedypy`.

### Briefly summarize the changes
1. Read `nutrition` metadata from knowledge graph query responses
1. Determine the scale factor for the nutritional metadata relative to the current ingredient
1. Include nutritional metadata in the service response

### How have the changes been tested?
1. Unit test coverage is provided