### PR TITLE
Nutrition: handle empty/null nutrition field values

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -92,7 +92,7 @@ def test_knowledge_graph_query():
                     'fat': 82.0,
                     'carbohydrates': 0.5,
                     'energy': 745.0,
-                    'fibre': 0.0,
+                    'fibre': None,
                 }
             },
             'query': {'markup': 'chunk of <mark>butter</mark>'},

--- a/web/app.py
+++ b/web/app.py
@@ -123,6 +123,7 @@ def determine_nutritional_content(ingredient):
         raise Exception(f"Unknown unit type: {ingredient['units']}")
 
     for nutrient, quantity in nutrition.items():
+        quantity = quantity or 0
         ratio = grams / 100.0
         scaled_quantity = quantity * ratio
         nutrition[nutrient] = round(scaled_quantity, 2)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Some ingredient nutrition maps may contain empty values - i.e. `null` in the corresponding JSON field value.  For example:

```json
{"product": "garlic powder", "recipe_count": 5243, "id": "garlic_powder", "domain": null, "parent_id": "garlic", "depth": 1, "nutrition": {"protein": 18.7, "fat": 1.2, "carbohydrates": 42.7, "energy": 246.0, "fibre": null, "product": "garlic powder"}}
```

This seems like a reasonable representation, and it's the current JSON format as it exists on-disk, so it seems worth handling this case.

### Briefly summarize the changes
1. Treat null/empty values in nutrition fields as zero

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Relates to openculinary/backend#24