### PR TITLE
Include relative density in API responses

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import json
 
 from web.app import (
+    attach_nutrition,
     parse_description,
     parse_quantities,
     retrieve_knowledge,
@@ -140,6 +141,7 @@ def test_knowledge_graph_query():
     )
 
     results = retrieve_knowledge(deepcopy(knowledge))
+    results = attach_nutrition(results)
 
     for description, ingredient in results.items():
         product = ingredient['product']

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -150,6 +150,9 @@ def test_knowledge_graph_query():
         nutrition = ingredient['nutrition']
         nutrition_expected = expected_nutrition.get(description)
 
+        if ingredient.get('units') == 'ml':
+            assert ingredient['relative_density'] is not None
+
         assert product['product'] == product_expected
         assert 'graph' in product['product_parser']
         assert nutrition == nutrition_expected

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -8,7 +8,7 @@ def request_tests():
             'product': 'red wine',
             'magnitude': 100,
             'units': 'ml',
-            'density': 1.0,
+            'relative_density': 1.0,
         },
         '1000 grams potatoes': {
             'product': 'potatoes',
@@ -24,13 +24,13 @@ def request_tests():
             'product': 'salt',
             'magnitude': 0.25,
             'units': 'ml',
-            'density': 1.0,
+            'relative_density': 1.0,
         },
         '2ml olive oil': {
             'product': 'olive oil',
             'magnitude': 2,
             'units': 'ml',
-            'density': 0.9,
+            'relative_density': 0.9,
         },
     }.items()
 
@@ -43,7 +43,9 @@ def test_request(client, knowledge_graph_stub, description, expected):
     assert ingredient['product']['product'] == expected['product']
     assert ingredient['magnitude'] == expected['magnitude']
     assert ingredient['units'] == expected['units']
-    assert ingredient.get('density') == expected.get('density')
+
+    if 'relative_density' in expected:
+        assert ingredient['relative_density'] == expected['relative_density']
 
 
 def test_request_dimensionless(client, knowledge_graph_stub):

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -24,7 +24,7 @@ def request_tests():
             'product': 'salt',
             'magnitude': 0.25,
             'units': 'ml',
-            'relative_density': 1.0,
+            'relative_density': 1.0,  # TODO: investigate this value
         },
         '2ml olive oil': {
             'product': 'olive oil',

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -8,6 +8,7 @@ def request_tests():
             'product': 'red wine',
             'magnitude': 100,
             'units': 'ml',
+            'density': 1.0,
         },
         '1000 grams potatoes': {
             'product': 'potatoes',
@@ -23,6 +24,13 @@ def request_tests():
             'product': 'salt',
             'magnitude': 0.25,
             'units': 'ml',
+            'density': 1.0,
+        },
+        '2ml olive oil': {
+            'product': 'olive oil',
+            'magnitude': 2,
+            'units': 'ml',
+            'density': 0.9,
         },
     }.items()
 
@@ -35,6 +43,7 @@ def test_request(client, knowledge_graph_stub, description, expected):
     assert ingredient['product']['product'] == expected['product']
     assert ingredient['magnitude'] == expected['magnitude']
     assert ingredient['units'] == expected['units']
+    assert ingredient.get('density') == expected.get('density')
 
 
 def test_request_dimensionless(client, knowledge_graph_stub):

--- a/web/app.py
+++ b/web/app.py
@@ -119,7 +119,7 @@ def determine_nutritional_content(ingredient):
         grams = ingredient['magnitude']
     elif ingredient['units'] == 'ml':
         # convert to grams based on density
-        grams = ingredient['magnitude'] * ingredient['density']
+        grams = ingredient['magnitude'] * ingredient['relative_density']
     else:
         raise Exception(f"Unknown unit type: {ingredient['units']}")
 
@@ -182,7 +182,7 @@ def get_base_units(quantity):
 
 def attach_nutrition(ingredients):
     for ingredient in ingredients.values():
-        ingredient['density'] = determine_relative_density(ingredient)
+        ingredient['relative_density'] = determine_relative_density(ingredient)
         ingredient['nutrition'] = determine_nutritional_content(ingredient)
     return ingredients
 

--- a/web/app.py
+++ b/web/app.py
@@ -88,6 +88,8 @@ def parse_description(description):
 
 
 def determine_relative_density(ingredient):
+    if ingredient.get('units') != 'ml':
+        return None
     product = ingredient['product']['product']
     if 'flour' in product:
         return 0.593
@@ -117,8 +119,7 @@ def determine_nutritional_content(ingredient):
         grams = ingredient['magnitude']
     elif ingredient['units'] == 'ml':
         # convert to grams based on density
-        relative_density = determine_relative_density(ingredient)
-        grams = ingredient['magnitude'] * relative_density
+        grams = ingredient['magnitude'] * ingredient['density']
     else:
         raise Exception(f"Unknown unit type: {ingredient['units']}")
 
@@ -156,12 +157,12 @@ def retrieve_knowledge(ingredients_by_product):
         ingredient['markup'] = knowledge[product]['query']['markup']
         ingredient['product'] = knowledge[product]['product']
         ingredient['product']['product_parser'] = 'knowledge-graph'
-        ingredient['nutrition'] = determine_nutritional_content(ingredient)
 
         # TODO: Remove this remapping once the database handles native IDs
         if 'id' in ingredient['product']:
             ingredient['product']['product_id'] = \
                 ingredient['product'].pop('id')
+
     return ingredients_by_product
 
 
@@ -179,6 +180,13 @@ def get_base_units(quantity):
     return dimensionalities.get(quantity.dimensionality)
 
 
+def attach_nutrition(ingredients):
+    for ingredient in ingredients.values():
+        ingredient['density'] = determine_relative_density(ingredient)
+        ingredient['nutrition'] = determine_nutritional_content(ingredient)
+    return ingredients
+
+
 def attach_markup(ingredients):
     for product, ingredient in ingredients.items():
         ingredients[product]['markup'] = render(ingredient)
@@ -192,6 +200,7 @@ def root():
 
     ingredients_by_product = parse_descriptions(descriptions)
     ingredients = retrieve_knowledge(ingredients_by_product)
+    ingredients = attach_nutrition(ingredients)
     ingredients = attach_markup(ingredients)
 
     return jsonify(ingredients)

--- a/web/app.py
+++ b/web/app.py
@@ -162,7 +162,6 @@ def retrieve_knowledge(ingredients_by_product):
         if 'id' in ingredient['product']:
             ingredient['product']['product_id'] = \
                 ingredient['product'].pop('id')
-
     return ingredients_by_product
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
During parsing of ingredients, the service currently calculates (naive) relative densities for quantities measured in milileters.  Downstream services *could* recalculate this value, and/or we could provide it as a shared library - but the simplest approach for now is simply to include the density value in API responses so that downstream can store it if they choose to.

### Briefly summarize the changes
1. Include the `relative_density` value in ingredient parser responses

### How have the changes been tested?
1. Basic unit test coverage is provided